### PR TITLE
use proper ionCube for machine type

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,8 +7,19 @@ pkgs.each do |pkg|
   end
 end
 
-remote_file "/usr/local/src/ioncube_loaders_lin_x86-64.tar.gz" do
-  source "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+case node[:kernel][:machine]
+when 'x86_64'
+  arch = 'x86-64'
+when /i[36]86/
+  arch = 'x86'
+else
+  arch = node[:kernel][:machine]
+end
+
+Chef::Log.info("using ionCube architecture #{arch}")
+
+remote_file "/usr/local/src/ioncube_loaders_lin_#{arch}.tar.gz" do
+  source "http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_#{arch}.tar.gz"
   mode "0644"
   action :create_if_missing
   notifies :run, "script[extract_ioncube_php]", :immediately
@@ -20,7 +31,7 @@ script "extract_ioncube_php" do
   cwd "/usr/local/src/"
   action :nothing
   code <<-EOH
-  tar xvfz /usr/local/src/ioncube_loaders_lin_x86-64.tar.gz
+  tar xvfz /usr/local/src/ioncube_loaders_lin_#{arch}.tar.gz
   mv /usr/local/src/ioncube /usr/local
   EOH
 end


### PR DESCRIPTION
This patch selects the ionCube plugin download based on the converging node's machine type as determined from the ohai data (node[:kernel][:machine]). It specifically handles x86_64, i386, and i686 machine types, and passes all others through on the off chance that ionCube might support ARM or MIPS, or Alpha in future. :-)
