### PR TITLE
no need to install wget

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,11 +1,4 @@
 include_recipe "php"
-pkgs = ["wget"]
-
-pkgs.each do |pkg|
-  package pkg do
-    action :install
-  end
-end
 
 case node[:kernel][:machine]
 when 'x86_64'


### PR DESCRIPTION
We should not need to install wget-- the remote_file provider doesn't need it to download the archive.
