### PR TITLE
remove service[apache2] notification

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,5 +53,4 @@ file "#{node['php']['ext_conf_dir']}/ioncube.ini" do
   group "root"
   mode "0644"
   action :create_if_missing
-  notifies :reload, resources(:service => "apache2")
 end


### PR DESCRIPTION
This is up the user to notify their dependent services.
