### PR TITLE
Set module priority to 00.

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -37,13 +37,13 @@ action :install do
       php_version = php_version_output.match(/PHP ([0-9]+\.[0-9]+)\.[0-9]+/)[1]
       Chef::Log.info("detected PHP version #{php_version}")
       ioncube_file_resource = run_context.resource_collection.find(:file => "#{run_context.node[:php][:ext_conf_dir]}/ioncube.ini")
-      ioncube_file_resource.content "zend_extension=/usr/local/ioncube/ioncube_loader_lin_" + php_version + ".so\n"
+      ioncube_file_resource.content "; priority=00\nzend_extension=/usr/local/ioncube/ioncube_loader_lin_" + php_version + ".so\n"
     end
     only_if { run_context.node[:php_ioncube][:version] == '' }
   end
 
   file "#{run_context.node[:php][:ext_conf_dir]}/ioncube.ini" do
-    content "zend_extension=/usr/local/ioncube/ioncube_loader_lin_" + run_context.node[:php_ioncube][:version] + ".so\n"  # dynamically defined during convergence in above ruby_block
+    content "; priority=00\nzend_extension=/usr/local/ioncube/ioncube_loader_lin_" + run_context.node[:php_ioncube][:version] + ".so\n"  # dynamically defined during convergence in above ruby_block
     owner "root"
     group "root"
     mode "0644"


### PR DESCRIPTION
Ioncube needs to be loaded first (or at least very early). Otherwise you will see an error: `The Loader must appear as the first entry in the php.ini file`. This can be done with `php5enmod` on Ubuntu 14.04 (and possibly other / older php module loading systems) by adding a comment that sets the priority, i.e.,

```
; priority=00
```
